### PR TITLE
fix(merging-sha): remove hard-corded branch name

### DIFF
--- a/lib/saddler/reporter/support/git/repository.rb
+++ b/lib/saddler/reporter/support/git/repository.rb
@@ -57,12 +57,15 @@ module Saddler
             @git.object("origin/#{tracking_branch_name}")
           end
 
+          def config
+            @git.config
+          end
+
           # http://stackoverflow.com/questions/4950725/how-do-i-get-git-to-show-me-which-branches-are-tracking-what
           # { "branch.spike/no-valid-master.merge" => "refs/heads/develop" }
           # => "develop"
           def tracking_branch_name
-            @git
-              .config
+            config
               .select { |k, _| /\Abranch.*merge\Z/ =~ k }
               .values
               .map do |v|

--- a/lib/saddler/reporter/support/git/repository.rb
+++ b/lib/saddler/reporter/support/git/repository.rb
@@ -49,8 +49,18 @@ module Saddler
             head # fallback
           end
 
+          def master
+            warn "[DEPRECATION] `#{self.class.name}#master` is deprecated.  Please use `#tracking` instead."
+            tracking
+          end
+
           def tracking
             @git.object(tracking_branch_name)
+          end
+
+          def origin_master
+            warn "[DEPRECATION] `#{self.class.name}#origin_master` is deprecated.  Please use `#origin_tracking` instead."
+            origin_tracking
           end
 
           def origin_tracking

--- a/test/test_git_repository.rb
+++ b/test/test_git_repository.rb
@@ -78,6 +78,62 @@ module Saddler
               end
             end
           end
+
+          sub_test_case 'stub remote develop and #tracking_branch_name' do
+            test '#tracking_branch_name' do
+              @repository.expects(:config).returns(
+                {
+                  'user.name' => 'example',
+                  'user.email' => 'who@example.com',
+                  'push.default' =>'simple',
+                  'remote.origin.url' => 'git@github.com:example/example.com.git',
+                  'remote.origin.fetch' => '+refs/heads/*:refs/remotes/origin/*',
+                  'branch.develop.remote' => 'origin',
+                  'branch.develop.merge' => 'refs/heads/develop',
+                  'branch.spike/no-valid-master.remote' => 'origin',
+                  'branch.spike/no-valid-master.merge' => 'refs/heads/develop'
+                })
+              assert do
+                @repository.tracking_branch_name == 'develop'
+              end
+            end
+          end
+
+          sub_test_case 'stub remote master and #tracking_branch_name' do
+            test '#tracking_branch_name' do
+              @repository.expects(:config).returns(
+                {
+                  'user.name' => 'example',
+                  'user.email' => 'who@example.com',
+                  'push.default' =>'simple',
+                  'remote.origin.url' => 'git@github.com:example/example.com.git',
+                  'remote.origin.fetch' => '+refs/heads/*:refs/remotes/origin/*',
+                  'branch.develop.remote' => 'origin',
+                  'branch.develop.merge' => 'refs/heads/master',
+                  'branch.spike/no-valid-master.remote' => 'origin',
+                  'branch.spike/no-valid-master.merge' => 'refs/heads/master'
+                })
+              assert do
+                @repository.tracking_branch_name == 'master'
+              end
+            end
+          end
+
+          sub_test_case 'stub no remote and #tracking_branch_name' do
+            test '#tracking_branch_name' do
+              @repository.expects(:config).returns(
+                {
+                  'user.name' => 'example',
+                  'user.email' => 'who@example.com',
+                  'push.default' =>'simple',
+                  'remote.origin.url' => 'git@github.com:example/example.com.git',
+                  'remote.origin.fetch' => '+refs/heads/*:refs/remotes/origin/*'
+                })
+              assert do
+                @repository.tracking_branch_name == nil
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Not a valid object name master (Git::GitExecuteError)
fixes #15
