### PR TITLE
Fix jenkins error: "commit_id is not part of the pull request"

### DIFF
--- a/lib/saddler/reporter/support/git/repository.rb
+++ b/lib/saddler/reporter/support/git/repository.rb
@@ -63,8 +63,15 @@ module Saddler
           # @return [::Git::Object] merging object
           def merging_object
             return head unless merge_commit?(head)
-            commit = head.parents.select do |parent|
-              ![dig_sha(tracking), dig_sha(origin_tracking)].compact.include?(parent.sha)
+            if ENV['ghprbActualCommit'] && !ENV['ghprbActualCommit'].empty?
+              # GitHub pull request builder plugin (for Jenkins)
+              commit = head.parents.select do |parent|
+                parent.sha == ENV['ghprbActualCommit']
+              end
+            else
+              commit = head.parents.select do |parent|
+                ![dig_sha(tracking), dig_sha(origin_tracking)].compact.include?(parent.sha)
+              end
             end
             return commit.last if commit.count == 1
             head # fallback


### PR DESCRIPTION
When Jenkins' workspace (= git worktree) is older than the pull-request branch, `saddler-reporter-support-git` cannot get merging object.
To fix this, use `$ghprbActualCommit` of GitHub Pull Request Builder.
